### PR TITLE
(SIMP-1587) Fix malformed metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Sep 29 2016  Chris Tessmer <chris.tessmer@onypoint.com> - 3.0.2-1
+- Fixed malformed dependency in `metadata.json`.
+
 * Mon Jun 27 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
 - Removed the hook to the es2unix packages since they have been replaced by the
   '_cat' endpoint.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "SIMP",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "elasticsearch/elasticsearch",
-      "version_requirement": "~> 0.11.0"
+      "version_requirement": ">= 0.11.0 < 0.12.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
The `metadata.json` used Gemfile-style "`~>`" syntax in the
`version_requirement` field.  This is invalid syntax for the Puppet
Forge, which fails with an error like:

```
ArgumentError: Invalid 'version_range' field in metadata.json:
Unparsable version range: "~> 0.11.0"
```

This patch fixes the issue by specifying explicit minimum and maximum
version numbers.

SIMP-1587 #close
