### PR TITLE
(SIMP-1450) Update to use new 'simp_apache'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.0-0
+- Updated to use the version of 'simp_apache' that does not conflict with
+  'puppetlabs/apache'.
+
 * Thu Sep 29 2016  Chris Tessmer <chris.tessmer@onypoint.com> - 3.0.2-1
 - Fixed malformed dependency in `metadata.json`.
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,10 +1,11 @@
 Requires: pupmod-elasticsearch-elasticsearch >= 0.11.0
 Requires: pupmod-puppetlabs-java >= 1.2.0
 Requires: pupmod-puppetlabs-stdlib
-Requires: pupmod-iptables >= 4.1.0
-Requires: pupmod-simplib >= 1.2.3
-Requires: pupmod-stunnel >= 4.2.3
-Requires: pupmod-sysctl >= 4.2.0
-Requires: pupmod-tcpwrappers >= 4.1.0
+Requires: pupmod-simp-simp_apache >= 5.0.0
+Requires: pupmod-simp-iptables >= 4.1.0
+Requires: pupmod-simp-simplib >= 1.2.3
+Requires: pupmod-simp-stunnel >= 4.2.3
+Requires: pupmod-simp-sysctl >= 4.2.0
+Requires: pupmod-simp-tcpwrappers >= 4.1.0
 Provides: pupmod-elasticsearch
 Obsoletes: pupmod-elasticsearch >= 2.0.0-1

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -25,7 +25,7 @@
 #     # If no value is assigned to the associated key then ['GET','POST','PUT']
 #     # is assumed.
 #
-#     # Values will be merged with those in simp_elasticsearch::apache::defaults
+#     # Values will be merged with those in simp_elasticsearch::simp_apache::defaults
 #     # if defined.
 #
 #     {
@@ -121,17 +121,17 @@ class simp_elasticsearch::apache (
   validate_port($proxyport)
 
   include '::simp_elasticsearch::apache::defaults'
-  include '::apache::validate'
+  include '::simp_apache::validate'
 
   # Make sure we were actually given a hash.
   validate_hash($method_acl)
 
   $_method_acl = deep_merge(
-    $::simp_elasticsearch::apache::defaults::method_acl,
+    $::simp_elasticsearch::simp_apache::defaults::method_acl,
     $method_acl
   )
 
-  validate_deep_hash( $::apache::validate::method_acl, $_method_acl)
+  validate_deep_hash( $::simp_apache::validate::method_acl, $_method_acl)
 
   # These only work because we guarantee that we have content here.
   validate_absolute_path($_method_acl['method']['file']['user_file'])
@@ -144,9 +144,9 @@ class simp_elasticsearch::apache (
     include 'apache::ssl'
     include 'apache::conf'
 
-    $_ssl_certificate_file = $::apache::ssl::sslcertificatefile
-    $_ssl_certificate_key_file = $::apache::ssl::sslcertificatekeyfile
-    $_ssl_ca_certificate_path = $::apache::ssl::sslcacertificatepath
+    $_ssl_certificate_file = $::simp_apache::ssl::sslcertificatefile
+    $_ssl_certificate_key_file = $::simp_apache::ssl::sslcertificatekeyfile
+    $_ssl_ca_certificate_path = $::simp_apache::ssl::sslcacertificatepath
 
     apache::add_site { 'elasticsearch':
       content => template("${module_name}/simp/etc/httpd/conf.d/elasticsearch.conf.erb")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "author": "SIMP",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp/simp_apache",
+      "version_requirement": ">= 5.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
Updated to use the version of 'simp_apache' that does not conflict with
'puppetlabs/apache'.

SIMP-1450 #comment Update to use deconflicted 'simp_apache'
SIMP-843 #comment Deconflicted 'simp_elasticsearch'
