### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,10 +1,19 @@
-Requires: pupmod-elasticsearch-elasticsearch >= 0.11.0
-Requires: pupmod-puppetlabs-java >= 1.2.0
-Requires: pupmod-puppetlabs-stdlib
+Obsoletes: pupmod-elasticsearch >= 2.0.0-1
+Provides: pupmod-elasticsearch
+Requires: pupmod-elasticsearch-elasticsearch < 1.0.0-0
+Requires: pupmod-elasticsearch-elasticsearch >= 0.11.0-0
 Requires: pupmod-iptables >= 4.1.0
+Requires: pupmod-puppetlabs-java < 2.0.0-0
+Requires: pupmod-puppetlabs-java >= 1.2.0-0
+Requires: pupmod-puppetlabs-java_ks < 2.0.0-0
+Requires: pupmod-puppetlabs-java_ks >= 1.4.0-0
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-iptables < 5.0.0-0
+Requires: pupmod-simp-iptables >= 4.1.4-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0
 Requires: pupmod-simplib >= 1.2.3
 Requires: pupmod-stunnel >= 4.2.3
 Requires: pupmod-sysctl >= 4.2.0
 Requires: pupmod-tcpwrappers >= 4.1.0
-Provides: pupmod-elasticsearch
-Obsoletes: pupmod-elasticsearch >= 2.0.0-1

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "SIMP",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -14,19 +14,27 @@
   "dependencies": [
     {
       "name": "elasticsearch/elasticsearch",
-      "version_requirement": ">= 0.11.0 < 0.12.0"
+      "version_requirement": ">= 0.11.0 < 1.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/java",
+      "version_requirement": ">= 1.2.0 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs/java_ks",
+      "version_requirement": ">= 1.4.0 < 2.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.2.3"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.4 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-simp_elasticsearch`
SIMP-1622 #close
