### PR TITLE
(SIMP-1583) Change Elasticsearch data directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Thu Sep 29 2016  Chris Tessmer <chris.tessmer@onypoint.com> - 3.0.2-1
+* Thu Oct 06 2016  Ralph Wright <ralph.wright@onyxpoint.com> - 3.0.3-0
+- Changed default data directory to /var
+- Updated Readme with SSL verify note
+
+* Thu Sep 29 2016  Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.0.2-1
 - Fixed malformed dependency in `metadata.json`.
 
 * Mon Jun 27 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0

--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,7 @@ To expose your cluster to external hosts, you will use the following Hiera confi
 
 .. code:: yaml
 
+  simp_elasticsearch::apache::ssl_verify_client: 'none'
   simp_elasticsearch::http_method_acl :
     'limits' :
       'hosts' :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,10 +190,11 @@ class simp_elasticsearch (
     config            => $_config,
     autoupgrade       => true,
     status            => 'enabled',
-    init_defaults  => deep_merge(
+    init_defaults     => deep_merge(
       $init_defaults,
       $::simp_elasticsearch::defaults::init_defaults
     ),
+    datadir           => "${data_dir}/data",
     restart_on_change => $restart_on_change
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "SIMP",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",


### PR DESCRIPTION
Modified the SIMP ES module to use /var as the default data
directory. It was defaulting to /usr.

SIMP-1583 #close
