### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -73,9 +73,6 @@ fixtures:
     stunnel:
       repo: https://github.com/simp/pupmod-simp-stunnel
       branch: master
-    sysctl:
-      repo: https://github.com/simp/pupmod-simp-sysctl
-      branch: master
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
       branch: master

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string_assignment-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Sun Nov 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.0-0
 - Fixed RPM dependencies
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -16,7 +16,7 @@ Requires: pupmod-simp-simplib < 3.0.0-0
 Requires: pupmod-simp-simplib >= 2.0.0-0
 Requires: pupmod-simp-stunnel < 6.0.0
 Requires: pupmod-simp-stunnel >= 5.0.0
-Requires: pupmod-simp-sysctl < 6.0.0
-Requires: pupmod-simp-sysctl >= 5.0.0
+Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
 Requires: pupmod-simp-tcpwrappers < 6.0.0
 Requires: pupmod-simp-tcpwrappers >= 5.0.0

--- a/manifests/simp_apache.pp
+++ b/manifests/simp_apache.pp
@@ -184,13 +184,7 @@ class simp_elasticsearch::simp_apache (
     }
 
     $_apache_limits = apache_limits($_method_acl['limits'])
-
-    file { "${es_httpd_includes}/limit/limits.conf":
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'apache',
-      mode    => '0640',
-      content => $_apache_limits ? {
+    $_apache_limits_content = $_apache_limits ? {
         # Set some sane defaults.
         ''      => "<Limit GET POST PUT DELETE>
             Order deny,allow
@@ -199,7 +193,14 @@ class simp_elasticsearch::simp_apache (
             Allow from ${::fqdn}
           </Limit>",
         default => "${_apache_limits}\n"
-      },
+    }
+
+    file { "${es_httpd_includes}/limit/limits.conf":
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'apache',
+      mode    => '0640',
+      content => $_apache_limits_content,
       notify  => Service['httpd']
     }
   }

--- a/manifests/simp_apache/defaults.pp
+++ b/manifests/simp_apache/defaults.pp
@@ -46,7 +46,7 @@ class simp_elasticsearch::simp_apache::defaults {
       # In general, this would be GET, POST, PUT, DELETE, HEAD, and OPTIONS
       'hosts'  => {
         '127.0.0.1' => 'defaults',
-        "$::fqdn"   => 'defaults'
+        "${::fqdn}"   => 'defaults'
       }
     }
   }

--- a/manifests/simp_apache/defaults.pp
+++ b/manifests/simp_apache/defaults.pp
@@ -13,7 +13,7 @@ class simp_elasticsearch::simp_apache::defaults {
     $_ldap_search = ''
   }
   else {
-    $_ldap_search = "ou=People,${$_base_dn}"
+    $_ldap_search = "ou=People,${_base_dn}"
   }
 
   $method_acl = {
@@ -25,7 +25,7 @@ class simp_elasticsearch::simp_apache::defaults {
       },
       # Use LDAP for access control
       'ldap'    => {
-        'enable'    => false,
+        'enable'      => false,
         'url'         => hiera('ldap::uri',''),
         'security'    => 'STARTTLS',
         'binddn'      => hiera('ldap::bind_dn',''),
@@ -45,8 +45,8 @@ class simp_elasticsearch::simp_apache::defaults {
       #
       # In general, this would be GET, POST, PUT, DELETE, HEAD, and OPTIONS
       'hosts'  => {
-        '127.0.0.1' => 'defaults',
-        "${::fqdn}"   => 'defaults'
+        '127.0.0.1'    => 'defaults',
+        $facts['fqdn'] => 'defaults'
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in simp-elasticsearch
SIMP-2245 #close