### PR TITLE
(SIMP-3048) Update pupmod-simp-simp_elasticsearch to Elasticsearch 5.X

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -29,9 +29,7 @@ fixtures:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
     elasticsearch:
-# use elastic repo until simp repo is updated
-#      repo: https://github.com/simp/puppet-elasticsearch
-      repo: https://github.com/elastic/puppet-elasticsearch
+      repo: https://github.com/simp/puppet-elasticsearch
       ref: 5.2.0
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,7 @@ fixtures:
   repositories:
     auditd:
       repo: https://github.com/simp/pupmod-simp-auditd
-#      ref: 7.0.1
-      branch: master
+      ref: 7.0.1
     augeasproviders_core:
       repo: https://github.com/simp/augeasproviders_core
       ref: simp6.0.0-2.1.3
@@ -22,8 +21,7 @@ fixtures:
       ref: simp6.0.0-2.1.0
     compliance_mapper:
       repo: https://github.com/simp/pupmod-simp-compliance_markup
-#      ref: 2.0.1
-      branch: master
+      ref: 2.0.1
     concat:
       repo: https://github.com/simp/puppetlabs-concat
       ref: simp6.0.0-2.2.0
@@ -43,54 +41,48 @@ fixtures:
       ref: 0.4.0
     iptables:
       repo: https://github.com/simp/pupmod-simp-iptables
-#      ref: 6.0.0-pre2
-      branch: master
+      ref: 6.0.1
     java:
       repo: https://github.com/simp/puppetlabs-java
       ref: simp-1.6.0-post1
     logrotate:
       repo: https://github.com/simp/pupmod-simp-logrotate
-#      ref: 6.0.0-pre1
-      branch: master
+      ref: 6.0.0
     oddjob:
       repo: https://github.com/simp/pupmod-simp-oddjob
-#      ref: 2.0.0-pre1
-      branch: master
+      ref: 2.0.0
     pam:
       repo: https://github.com/simp/pupmod-simp-pam
-#      ref: 6.0.0-pre1
-      branch: master
+      ref: 6.0.2
     pki:
       repo: https://github.com/simp/pupmod-simp-pki
-#      ref: 6.0.0-pre2
-      branch: master
+      ref: 6.0.0
     rsync:
       repo: https://github.com/simp/pupmod-simp-rsync
-#      ref: 6.0.0-pre1
-      branch: master
+      ref: 6.0.2
     rsyslog:
       repo: https://github.com/simp/pupmod-simp-rsyslog
-#      ref: 7.0.0-pre1
-      branch: master
+      ref: 7.0.2
     simp_apache:
       repo: https://github.com/simp/pupmod-simp-apache
-#      ref: 6.0.0-pre1
-      branch: master
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
+      ref: 6.0.0
+    simp_options:
+      repo: https://github.com/simp/pupmod-simp-simp_options
+      ref: 1.0.2
     simpcat:
       repo: https://github.com/simp/pupmod-simp-simpcat
-#      ref: 6.0.0-pre1
-      branch: master
+      ref: 6.0.0
     simplib:
       repo: https://github.com/simp/pupmod-simp-simplib
-#      ref: 3.1.0-pre3
-      branch: master
+      ref: 3.2.0
     stdlib:
       repo: https://github.com/simp/puppetlabs-stdlib
       ref: simp6.0.0-4.13.1
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
-#      ref: 6.0.0-pre1
-      branch: master
+      ref: 6.0.0
+    yum:
+      repo: https://github.com/voxpupuli/puppet-yum
+      ref: v1.0.0
   symlinks:
     simp_elasticsearch: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -31,8 +31,10 @@ fixtures:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
     elasticsearch:
-      repo: https://github.com/simp/puppet-elasticsearch
-      ref: 5.1.0
+# use elastic repo until simp repo is updated
+#      repo: https://github.com/simp/puppet-elasticsearch
+      repo: https://github.com/elastic/puppet-elasticsearch
+      ref: 5.2.0
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,79 +3,92 @@ fixtures:
   repositories:
     auditd:
       repo: https://github.com/simp/pupmod-simp-auditd
-      ref: 7.0.0-pre1
+#      ref: 7.0.1
+      branch: master
     augeasproviders_core:
       repo: https://github.com/simp/augeasproviders_core
-      ref: simp-2.1.1
+      ref: simp6.0.0-2.1.3
     augeasproviders_grub:
       repo: https://github.com/simp/augeasproviders_grub
-      ref: simp-2.3.1
+      ref: simp6.0.0-2.4.0
     augeasproviders_puppet:
       repo: https://github.com/simp/augeasproviders_puppet
       ref: simp-2.1.0
     augeasproviders_ssh:
       repo: https://github.com/simp/augeasproviders_ssh
-      ref: simp-2.5.0
+      ref: simp6.0.0-2.5.0
     augeasproviders_sysctl:
       repo: https://github.com/simp/augeasproviders_sysctl
-      ref: simp-2.1.0
+      ref: simp6.0.0-2.1.0
     compliance_mapper:
       repo: https://github.com/simp/pupmod-simp-compliance_markup
-      ref: 2.0.0
+#      ref: 2.0.1
+      branch: master
     concat:
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 2.2.0
+      ref: simp6.0.0-2.2.0
     datacat:
       repo: https://github.com/simp/puppet-datacat
-      ref: simp-0.6.2
+      ref: simp6.0.0-0.6.2
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
-      ref: simp-0.15.1
+      ref: 5.1.0
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
-      ref: simp-1.0.1
+      ref: simp6.0.0-1.0.1
     haveged:
       repo: https://github.com/simp/puppet-haveged
-      ref: simp-0.4.0-pre1
+      ref: 0.4.0
     iptables:
       repo: https://github.com/simp/pupmod-simp-iptables
-      ref: 6.0.0-pre2
+#      ref: 6.0.0-pre2
+      branch: master
     java:
       repo: https://github.com/simp/puppetlabs-java
       ref: simp-1.6.0-post1
     logrotate:
       repo: https://github.com/simp/pupmod-simp-logrotate
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
     oddjob:
       repo: https://github.com/simp/pupmod-simp-oddjob
-      ref: 2.0.0-pre1
+#      ref: 2.0.0-pre1
+      branch: master
     pam:
       repo: https://github.com/simp/pupmod-simp-pam
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
     pki:
       repo: https://github.com/simp/pupmod-simp-pki
-      ref: 6.0.0-pre2
+#      ref: 6.0.0-pre2
+      branch: master
     rsync:
       repo: https://github.com/simp/pupmod-simp-rsync
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
     rsyslog:
       repo: https://github.com/simp/pupmod-simp-rsyslog
-      ref: 7.0.0-pre1
+#      ref: 7.0.0-pre1
+      branch: master
     simp_apache:
       repo: https://github.com/simp/pupmod-simp-apache
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     simpcat:
       repo: https://github.com/simp/pupmod-simp-simpcat
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
     simplib:
       repo: https://github.com/simp/pupmod-simp-simplib
-      ref: 3.1.0-pre3
+#      ref: 3.1.0-pre3
+      branch: master
     stdlib:
       repo: https://github.com/simp/puppetlabs-stdlib
-      ref: 4.13.1
+      ref: simp6.0.0-4.13.1
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
-      ref: 6.0.0-pre1
+#      ref: 6.0.0-pre1
+      branch: master
   symlinks:
     simp_elasticsearch: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 /.rspec_system
 /.vagrant
 /.bundle
+/Gemfile.lock
 /vendor
 /junit
 /log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 # S6.0.0  4.7  2.1.9
 ---
 language: ruby
-sudo: true
+sudo: false
 cache: bundler
 before_script:
   - bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,15 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Apr 26 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+* Wed Apr 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Update to work with Elasticsearch 5.3
 
 * Wed Feb 01 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.1-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Apr 26 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+- Update to work with Elasticsearch 5.3
+
 * Wed Feb 01 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.1-0
 - All hiera() lookups changed to lookup() or simplib::lookup()
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
+# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
 # ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
-# ------------------------------------------------------------------------------
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources   = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~>4.8.0') # Default to SIMP 6
   gem 'rspec'
   gem 'rspec-puppet'
+  gem 'puppet-strings'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
 end
 
 group :development do
@@ -24,7 +24,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
@@ -35,8 +34,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,23 +30,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
+    CFPropertyList (2.3.5)
     addressable (2.4.0)
-    aws-sdk-v1 (1.66.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
-    backports (3.6.8)
-    beaker-answers (0.13.0)
+      nokogiri (~> 1)
+    backports (3.8.0)
+    beaker-answers (0.17.0)
       hocon (~> 1.0)
       require_all (~> 1.3.2)
       stringify-hash (~> 0.0.0)
     beaker-hiera (0.1.1)
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (0.8.2)
+    beaker-hostgenerator (0.8.4)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-pe (0.12.1)
+    beaker-pe (0.12.2)
       stringify-hash (~> 0.0.0)
+    beaker-puppet_install_helper (0.7.1)
+      beaker (>= 2.0)
     beaker-rspec (5.6.0)
       beaker (~> 2.0)
       rspec
@@ -58,23 +60,22 @@ GEM
     cri (2.6.1)
       colored (~> 1.2)
     deep_merge (1.1.1)
-    diff-lcs (1.2.5)
-    docker-api (1.33.1)
+    diff-lcs (1.3)
+    docker-api (1.33.4)
       excon (>= 0.38.0)
       json
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    excon (0.54.0)
+    excon (0.55.0)
     facter (2.4.6)
-      CFPropertyList (~> 2.2.6)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     fast_gettext (1.1.0)
-    ffi (1.9.17)
+    ffi (1.9.18)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.34.0)
@@ -104,7 +105,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (1.1.0)
+    fog-aws (1.3.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -169,18 +170,18 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.2)
+    fog-xml (0.1.3)
       fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
+      nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
     gettext (3.2.2)
       locale (>= 2.0.5)
       text (>= 1.3.0)
-    gettext-setup (0.11)
+    gettext-setup (0.24)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
       locale
-    gh (0.15.0)
+    gh (0.15.1)
       addressable (~> 2.4.0)
       backports
       faraday (~> 0.8)
@@ -205,7 +206,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    guard (2.14.0)
+    guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (~> 1.0)
@@ -217,15 +218,15 @@ GEM
     guard-rake (1.0.0)
       guard
       rake
-    hiera (3.2.2)
+    hiera (3.3.1)
     hiera-puppet-helper (1.0.1)
     highline (1.7.8)
-    hocon (1.2.4)
+    hocon (1.2.5)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
     hurley (0.2)
-    in-parallel (0.1.15)
+    in-parallel (0.1.17)
     inflecto (0.0.2)
     inifile (2.0.2)
     ipaddress (0.8.3)
@@ -240,13 +241,13 @@ GEM
     little-plugger (1.1.4)
     locale (2.1.2)
     log4r (1.1.10)
-    logging (2.1.0)
+    logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     lumberjack (1.0.11)
     memoist (0.15.0)
     metaclass (0.0.4)
-    metadata-json-lint (1.0.0)
+    metadata-json-lint (1.1.0)
       json
       semantic_puppet (>= 0.1.2, < 2.0.0)
       spdx-licenses (~> 1.0)
@@ -267,7 +268,7 @@ GEM
     net-ssh (2.9.4)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -275,8 +276,8 @@ GEM
     open_uri_redirections (0.2.1)
     os (0.9.6)
     pager (1.0.1)
-    parallel (1.10.0)
-    parallel_tests (2.13.0)
+    parallel (1.11.1)
+    parallel_tests (2.14.1)
       parallel
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -285,50 +286,48 @@ GEM
     pry-doc (0.10.0)
       pry (~> 0.9)
       yard (~> 0.9)
-    puppet (4.8.1)
-      CFPropertyList (~> 2.2.6)
+    puppet (4.8.2)
       facter (> 2.0, < 4)
       hiera (>= 2.0, < 4)
       json_pure (~> 1.8)
     puppet-blacksmith (3.4.0)
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
-    puppet-lint (2.1.0)
+    puppet-lint (2.2.1)
     puppet-lint-empty_string-check (0.2.2)
       puppet-lint (>= 1.0, < 3.0)
     puppet-lint-trailing_comma-check (0.3.2)
       puppet-lint (>= 1.0, < 3.0)
-    puppet-strings (1.0.0)
+    puppet-strings (1.1.0)
       yard (~> 0.9.5)
-    puppet-syntax (2.2.0)
+    puppet-syntax (2.4.0)
       rake
-    puppet_forge (2.2.2)
+    puppet_forge (2.2.4)
       faraday (~> 0.9.0)
       faraday_middleware (>= 0.9.0, < 0.11.0)
-      gettext-setup (>= 0.3)
+      gettext-setup (~> 0.11)
       minitar
       semantic_puppet (~> 0.1.0)
-    puppetlabs_spec_helper (0.10.3)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
+    puppetlabs_spec_helper (1.2.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    r10k (2.5.1)
+    r10k (2.5.4)
       colored (= 1.2)
       cri (~> 2.6.1)
       gettext-setup (~> 0.5)
       log4r (= 1.1.10)
-      minitar
+      minitar (= 0.5.4)
       multi_json (~> 1.10)
       puppet_forge (~> 2.2)
       semantic_puppet (~> 0.1.0)
-    rake (11.3.0)
+    rake (12.0.0)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.7)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rbvmomi (1.8.2)
       builder
@@ -366,7 +365,7 @@ GEM
     rsync (1.0.9)
     semantic_puppet (0.1.4)
       gettext-setup (>= 0.3)
-    serverspec (2.37.2)
+    serverspec (2.38.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
@@ -378,9 +377,10 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.5.7)
+    simp-beaker-helpers (1.6.0)
       beaker (~> 2)
-    simp-rake-helpers (3.1.3)
+      beaker-puppet_install_helper (~> 0.6)
+    simp-rake-helpers (3.4.0)
       beaker (~> 2.51)
       beaker-rspec (~> 5.0)
       bundler (~> 1.0)
@@ -392,9 +392,9 @@ GEM
       puppet (>= 3.0)
       puppet-blacksmith (~> 3.3)
       puppet-lint (>= 1.0, < 3.0)
-      puppetlabs_spec_helper (~> 0.0)
+      puppetlabs_spec_helper (~> 1.0)
       r10k (~> 2.2)
-      rake (>= 10.0, < 12.0)
+      rake (>= 10.0, < 13.0)
       rspec (~> 3.0)
       rspec-core (~> 3.0)
       simp-beaker-helpers (~> 1.0)
@@ -405,15 +405,15 @@ GEM
       rspec-puppet-facts (~> 0)
     slop (3.6.0)
     spdx-licenses (1.1.0)
-    specinfra (2.66.3)
+    specinfra (2.67.9)
       net-scp
-      net-ssh (>= 2.7, < 4.0)
+      net-ssh (>= 2.7, < 5.0)
       net-telnet
       sfl
     stringify-hash (0.0.2)
     text (1.3.1)
     thor (0.19.4)
-    travis (1.8.5)
+    travis (1.8.8)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
@@ -424,16 +424,16 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     travis-lint (2.0.0)
       json
-    travish (0.1.1)
+    travish (1.0.0)
     trollop (2.1.2)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    websocket (1.2.3)
-    yard (0.9.8)
+    unf_ext (0.0.7.4)
+    websocket (1.2.4)
+    yard (0.9.9)
 
 PLATFORMS
   ruby
@@ -447,7 +447,7 @@ DEPENDENCIES
   metadata-json-lint
   pry
   pry-doc
-  puppet (~> 4)
+  puppet (= 4.8.2)
   puppet-blacksmith
   puppet-lint-empty_string-check
   puppet-lint-trailing_comma-check
@@ -464,4 +464,4 @@ DEPENDENCIES
   travish
 
 BUNDLED WITH
-   1.13.3
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     backports (3.8.0)
-    beaker (3.15.0)
+    beaker (3.16.0)
       aws-sdk-v1 (~> 1.57)
       beaker-hiera (~> 0.0)
       beaker-hostgenerator
@@ -193,7 +193,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.9.1)
+    fog-vsphere (1.9.2)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -272,7 +272,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    lumberjack (1.0.11)
+    lumberjack (1.0.12)
     memoist (0.15.0)
     metaclass (0.0.4)
     metadata-json-lint (1.1.0)
@@ -435,7 +435,7 @@ GEM
       rspec-puppet-facts (~> 0)
     slop (3.6.0)
     spdx-licenses (1.1.0)
-    specinfra (2.67.9)
+    specinfra (2.67.10)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (1.44.1)
+    fog-core (1.44.2)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
@@ -478,7 +478,7 @@ DEPENDENCIES
   metadata-json-lint
   pry
   pry-doc
-  puppet (= 4.8.2)
+  puppet (~> 4.8.0)
   puppet-blacksmith
   puppet-lint-empty_string-check
   puppet-lint-trailing_comma-check

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
     minitar (0.5.4)
-    minitest (5.10.1)
+    minitest (5.10.2)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
@@ -296,7 +296,7 @@ GEM
     net-ssh (4.1.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -395,7 +395,7 @@ GEM
     rsync (1.0.9)
     semantic_puppet (0.1.4)
       gettext-setup (>= 0.3)
-    serverspec (2.38.0)
+    serverspec (2.38.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
@@ -407,7 +407,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.8.1)
+    simp-beaker-helpers (1.7.1)
       beaker (~> 3.14)
       beaker-puppet_install_helper (~> 0.6)
     simp-rake-helpers (3.5.0)
@@ -478,7 +478,7 @@ DEPENDENCIES
   metadata-json-lint
   pry
   pry-doc
-  puppet (~> 4.8.0)
+  puppet (= 4.8.2)
   puppet-blacksmith
   puppet-lint-empty_string-check
   puppet-lint-trailing_comma-check

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,3 @@
-GIT
-  remote: https://github.com/trevor-vaughan/beaker.git
-  revision: 4e10bde3e1bd2da3f6aa8a47cbbb5a42c99194f7
-  branch: BKR-931-2.51.0
-  specs:
-    beaker (2.51.0)
-      aws-sdk-v1 (~> 1.57)
-      beaker-answers (~> 0.0)
-      beaker-hiera (~> 0.0)
-      beaker-hostgenerator
-      beaker-pe (~> 0.0)
-      docker-api
-      fission (~> 0.4)
-      fog (~> 1.25, < 1.35.0)
-      fog-google (~> 0.0.9)
-      google-api-client (~> 0.8, < 0.9.5)
-      hocon (~> 1.0)
-      in-parallel (~> 0.1)
-      inifile (~> 2.0)
-      json (~> 1.8)
-      minitest (~> 5.4)
-      net-scp (~> 1.2)
-      net-ssh (~> 2.9)
-      open_uri_redirections (~> 0.2.1)
-      rbvmomi (~> 1.8, < 1.9.0)
-      rsync (~> 1.0.9)
-      stringify-hash (~> 0.0)
-      unf (~> 0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -36,22 +7,37 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     backports (3.8.0)
-    beaker-answers (0.17.0)
+    beaker (3.15.0)
+      aws-sdk-v1 (~> 1.57)
+      beaker-hiera (~> 0.0)
+      beaker-hostgenerator
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.38)
+      google-api-client (~> 0.9)
       hocon (~> 1.0)
-      require_all (~> 1.3.2)
-      stringify-hash (~> 0.0.0)
+      in-parallel (~> 0.1)
+      inifile (~> 3.0)
+      minitar (~> 0.5.4)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 4.0)
+      open_uri_redirections (~> 0.2.1)
+      rbvmomi (~> 1.9)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      thor (~> 0.19)
+      unf (~> 0.1)
     beaker-hiera (0.1.1)
       stringify-hash (~> 0.0.0)
     beaker-hostgenerator (0.8.4)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-pe (0.12.2)
-      stringify-hash (~> 0.0.0)
     beaker-puppet_install_helper (0.7.1)
       beaker (>= 2.0)
-    beaker-rspec (5.6.0)
-      beaker (~> 2.0)
-      rspec
+    beaker-rspec (6.1.0)
+      beaker (~> 3.0)
+      rspec (~> 3.0)
       serverspec (~> 2)
       specinfra (~> 2)
     builder (3.2.3)
@@ -59,6 +45,8 @@ GEM
     colored (1.2)
     cri (2.6.1)
       colored (~> 1.2)
+    declarative (0.0.9)
+    declarative-option (0.1.0)
     deep_merge (1.1.1)
     diff-lcs (1.3)
     docker-api (1.33.4)
@@ -78,18 +66,24 @@ GEM
     ffi (1.9.18)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.34.0)
+    fog (1.40.0)
+      fog-aliyun (>= 0.1.0)
       fog-atmos
       fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.32)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.43)
+      fog-digitalocean (>= 0.3.0)
+      fog-dnsimple (~> 1.0)
       fog-dynect (~> 0.0.2)
       fog-ecloud (~> 0.1)
-      fog-google (>= 0.0.2)
+      fog-google (<= 0.1.0)
       fog-json
       fog-local
+      fog-openstack
       fog-powerdns (>= 0.1.1)
       fog-profitbricks
+      fog-rackspace
       fog-radosgw (>= 0.0.2)
       fog-riakcs
       fog-sakuracloud (>= 0.0.4)
@@ -99,9 +93,16 @@ GEM
       fog-terremark
       fog-vmfusion
       fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
+      json (>= 1.8, < 2.0)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
     fog-atmos (0.1.0)
       fog-core
       fog-xml
@@ -114,10 +115,23 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.43.0)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.44.1)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
+    fog-digitalocean (0.3.0)
+      fog-core (~> 1.42)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.5)
+    fog-dnsimple (1.0.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
     fog-dynect (0.0.3)
       fog-core
       fog-json
@@ -125,7 +139,7 @@ GEM
     fog-ecloud (0.3.0)
       fog-core
       fog-xml
-    fog-google (0.0.9)
+    fog-google (0.1.0)
       fog-core
       fog-json
       fog-xml
@@ -134,6 +148,10 @@ GEM
       multi_json (~> 1.10)
     fog-local (0.3.1)
       fog-core (~> 1.27)
+    fog-openstack (0.1.20)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
     fog-powerdns (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -141,6 +159,11 @@ GEM
     fog-profitbricks (3.0.0)
       fog-core (~> 1.42)
       fog-json (~> 1.0)
+    fog-rackspace (0.1.5)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
     fog-radosgw (0.0.5)
       fog-core (>= 1.21.0)
       fog-json
@@ -170,6 +193,12 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
+    fog-vsphere (1.9.1)
+      fog-core
+      rbvmomi (~> 1.9)
+    fog-xenserver (0.3.0)
+      fog-core
+      fog-xml
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
@@ -188,16 +217,15 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (~> 2.9)
       net-http-pipeline
-    google-api-client (0.9.4)
+    google-api-client (0.10.3)
       addressable (~> 2.3)
       googleauth (~> 0.5)
       httpclient (~> 2.7)
       hurley (~> 0.1)
       memoist (~> 0.11)
       mime-types (>= 1.6)
-      representable (~> 2.3.0)
-      retriable (~> 2.0)
-      thor (~> 0.19)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
     googleauth (0.5.1)
       faraday (~> 0.9)
       jwt (~> 1.4)
@@ -228,7 +256,7 @@ GEM
     hurley (0.2)
     in-parallel (0.1.17)
     inflecto (0.0.2)
-    inifile (2.0.2)
+    inifile (3.0.0)
     ipaddress (0.8.3)
     json (1.8.6)
     json_pure (1.8.6)
@@ -265,7 +293,7 @@ GEM
     net-http-pipeline (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.4)
+    net-ssh (4.1.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
     nokogiri (1.7.1)
@@ -276,7 +304,7 @@ GEM
     open_uri_redirections (0.2.1)
     os (0.9.6)
     pager (1.0.1)
-    parallel (1.11.1)
+    parallel (1.11.2)
     parallel_tests (2.14.1)
       parallel
     pry (0.10.4)
@@ -329,39 +357,41 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
-    representable (2.3.0)
-      uber (~> 0.0.7)
-    require_all (1.3.3)
+    rbvmomi (1.11.2)
+      builder (~> 3.0)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      trollop (~> 2.1)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (2.1.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    retriable (3.0.2)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
+      rspec-support (~> 3.6.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.5.0)
+    rspec-mocks (3.6.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
+      rspec-support (~> 3.6.0)
     rspec-puppet (2.5.0)
       rspec
     rspec-puppet-facts (0.12.0)
       facter
       json
-    rspec-support (3.5.0)
+    rspec-support (3.6.0)
     rsync (1.0.9)
     semantic_puppet (0.1.4)
       gettext-setup (>= 0.3)
@@ -377,12 +407,12 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.6.0)
-      beaker (~> 2)
+    simp-beaker-helpers (1.8.1)
+      beaker (~> 3.14)
       beaker-puppet_install_helper (~> 0.6)
-    simp-rake-helpers (3.4.0)
-      beaker (~> 2.51)
-      beaker-rspec (~> 5.0)
+    simp-rake-helpers (3.5.0)
+      beaker (~> 3.14)
+      beaker-rspec (~> 6.1)
       bundler (~> 1.0)
       coderay (~> 1.0)
       listen (~> 3.0.6)
@@ -428,18 +458,19 @@ GEM
     trollop (2.1.2)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    uber (0.0.15)
+    uber (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
     websocket (1.2.4)
+    xml-simple (1.1.5)
     yard (0.9.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  beaker!
+  beaker
   beaker-rspec
   guard-rake
   hiera-puppet-helper
@@ -447,7 +478,7 @@ DEPENDENCIES
   metadata-json-lint
   pry
   pry-doc
-  puppet (= 4.8.2)
+  puppet (~> 4.8.0)
   puppet-blacksmith
   puppet-lint-empty_string-check
   puppet-lint-trailing_comma-check
@@ -456,8 +487,8 @@ DEPENDENCIES
   rake
   rspec
   rspec-puppet
-  simp-beaker-helpers (~> 1.5)
-  simp-rake-helpers (~> 3.0)
+  simp-beaker-helpers (~> 1.7)
+  simp-rake-helpers (~> 3.5)
   simp-rspec-puppet-facts (~> 1.3)
   travis
   travis-lint

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ To expose your cluster to external hosts, you will use the following Hiera confi
 
   # This is required for use with Grafana. If you are not using Grafana, you
   # should require client validation (default) if at all possible.
-  simp_elasticsearch::apache::ssl_verify_client: 'none'
+  simp_elasticsearch::simp_apache::ssl_verify_client: 'none'
 
   simp_elasticsearch::http_method_acl :
     'limits' :

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,13 @@ In Hiera, you can define this as follows:
 
   simp_elasticsearch::cluster_name : 'my_cluster'
 
+In addition, for EL6 systems, ensure the correct version of JAVA is
+installed as follows:
+
+.. code:: yaml
+
+  java::package : 'java-1.8.0-openjdk-devel'
+
 Setting up a Multi-Node Cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -131,6 +138,12 @@ can use in the place of `::ipaddress` below.
     - first.cluster.host:9300
     - second.cluster.host:9300
     - third.cluster.host:9300
+
+Be sure to specify the correct version of JAVA for EL6 systems as follows:
+
+.. code:: yaml
+
+  java::package : 'java-1.8.0-openjdk-devel'
 
 Enabling Remote Connections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -2,8 +2,8 @@ Obsoletes: pupmod-simp-elasticsearch >= 2.0.0-1
 Provides: pupmod-simp-elasticsearch >= 2.0.0-1
 Obsoletes: pupmod-elasticsearch >= 2.0.0-1
 Provides: pupmod-elasticsearch >= 2.0.0-1
-Requires: pupmod-elasticsearch-elasticsearch < 1.0.0-0
-Requires: pupmod-elasticsearch-elasticsearch >= 0.11.0-0
+Requires: pupmod-elastic-elasticsearch < 6.0.0-0
+Requires: pupmod-elastic-elasticsearch >= 5.2.0-0
 Requires: pupmod-puppetlabs-java < 2.0.0
 Requires: pupmod-puppetlabs-java >= 1.6.0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0

--- a/files/opts.conf
+++ b/files/opts.conf
@@ -1,0 +1,10 @@
+# This file is managed by Puppet.
+
+[Service]
+
+# Clear startup command provided by system config
+LimitNPROC=
+
+# Define the new nproc limit
+LimitNPROC=2048
+

--- a/files/opts.conf
+++ b/files/opts.conf
@@ -2,9 +2,5 @@
 
 [Service]
 
-# Clear startup command provided by system config
-LimitNPROC=
-
 # Define the new nproc limit
 LimitNPROC=2048
-

--- a/lib/puppet/parser/functions/es_systemd_escape.rb
+++ b/lib/puppet/parser/functions/es_systemd_escape.rb
@@ -1,0 +1,19 @@
+module Puppet::Parser::Functions
+
+  newfunction(:es_systemd_escape, :type => :rvalue, :arity =>1, :doc => <<-'ENDHEREDOC') do |args|
+    Create a string suitable for use in the name of a systemd service file.
+
+    This mimics systemd-escape.
+
+    ENDHEREDOC
+
+    raise Puppet::ParseError, "es_systemd_escape(): Expects a string argument, got " +
+      "#{args[0].inspect} which is of type #{args[0].class}" unless args[0].is_a?(String)
+
+    escaped_string = args[0].gsub(/([^a-zA-Z0-9_.:\/]+)/n) do
+      '\x' + $1.unpack('H2' * $1.size).join('\x')
+    end
+    escaped_string.gsub('/', '-')
+  end
+
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,11 +50,11 @@ class simp_elasticsearch::config {
 
   # Change the home directory
   user {  $::elasticsearch::elasticsearch_user:
-    ensure     => 'present',
-    comment    => 'elasticsearch user',
-    home       => '/var/local/elasticsearch',
-    shell      => '/sbin/nologin',
-    system     => true
+    ensure  => 'present',
+    comment => 'elasticsearch user',
+    home    => '/var/local/elasticsearch',
+    shell   => '/sbin/nologin',
+    system  => true
   }
 
   # Make sure directory exists
@@ -62,10 +62,10 @@ class simp_elasticsearch::config {
   # 'managehome' attribute to true won't create the directory for a user
   # that already exists.
   file { '/var/local/elasticsearch':
-    ensure  => 'directory',
-    group   =>  $::elasticsearch::elasticsearch_group,
-    owner   =>  $::elasticsearch::elasticsearch_user,
-    mode    => '0770',
+    ensure => 'directory',
+    group  =>  $::elasticsearch::elasticsearch_group,
+    owner  =>  $::elasticsearch::elasticsearch_user,
+    mode   => '0770',
   }
 
   # Create tmp directory for JNA

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,81 @@
+# This class makes adjustments to files/system parameters
+# used by for the elasticsearch service, so that this
+# service can run in a SIMP environment.
+#
+class simp_elasticsearch::config {
+  assert_private()
+  # Correct the permissions on the ES templates directory
+  # TODO Verify this workaround is still required.
+  file { '/etc/elasticsearch/templates_import':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
+  file { $::elasticsearch::config['path.data']:
+    ensure  => 'directory',
+    owner   => $::elasticsearch::elasticsearch_user,
+    group   => $::elasticsearch::elasticsearch_group,
+    require => Package['elasticsearch']
+  }
+
+  # This is here due to some weird bug in ES that won't read /etc properly.
+  # TODO Verify this workaround is still required.
+  file { '/usr/share/elasticsearch/config':
+    ensure => 'symlink',
+    target => '/etc/elasticsearch',
+    force  => true
+  }
+
+  pam::limits::rule { 'es_heap_sizelock':
+    domains => [ $::elasticsearch::elasticsearch_user ],
+    type    => '-',
+    item    => 'memlock',
+    value   => 'unlimited',
+    order   => 0,
+  }
+
+  # Out-of-the-box, ES will not start in a SIMP environment because
+  # JNA is configured to use /tmp as its tmpdir and /tmp is set to
+  # noexec.  We can configure the JNA directory via JVM options,
+  # but, this causes ES to core unless the ES user's home directory
+  # exists. Unfortunately, that directory is set to /home/elasticsearch
+  # when the ES user is created in the elasticsearch RPM post-install.
+  # This directory is not universally appropriate (e.g. when /home
+  # is a NFS-mounted system), so to solve the JNA problem, we need
+  # to both set the JNA tmpdir JVM option (see
+  # simp_elasticsearch::jvm_options_defaults) and change the ES user
+  # home directory to one more suitable for a service.
+
+  # Change the home directory
+  user {  $::elasticsearch::elasticsearch_user:
+    ensure     => 'present',
+    comment    => 'elasticsearch user',
+    home       => '/var/local/elasticsearch',
+    shell      => '/sbin/nologin',
+    system     => true
+  }
+
+  # Make sure directory exists
+  # NOTE:  Can't do this in the user resource above, because setting the
+  # 'managehome' attribute to true won't create the directory for a user
+  # that already exists.
+  file { '/var/local/elasticsearch':
+    ensure  => 'directory',
+    group   =>  $::elasticsearch::elasticsearch_group,
+    owner   =>  $::elasticsearch::elasticsearch_user,
+    mode    => '0770',
+  }
+
+  # Create tmp directory for JNA
+  #TODO set up systemd-tmpfiles/tmpwatch rule for this dir, if needed
+  file { $::simp_elasticsearch::jna_tmpdir:
+    ensure  => 'directory',
+    group   =>  $::elasticsearch::elasticsearch_group,
+    owner   =>  $::elasticsearch::elasticsearch_user,
+    mode    => '0770',
+    seltype => 'tmp_t',
+  }
+
+}

--- a/manifests/default_instance.pp
+++ b/manifests/default_instance.pp
@@ -4,8 +4,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
-#
 class simp_elasticsearch::default_instance {
   include '::simp_elasticsearch'
   assert_private()

--- a/manifests/default_instance.pp
+++ b/manifests/default_instance.pp
@@ -7,5 +7,7 @@
 # @copyright 2016 Onyx Point, Inc.
 #
 class simp_elasticsearch::default_instance {
-  elasticsearch::instance{ 'simp': }
+  include '::simp_elasticsearch'
+  assert_private()
+  elasticsearch::instance{ $::simp_elasticsearch::default_instance_name: }
 }

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -27,9 +27,9 @@ class simp_elasticsearch::defaults {
   # JNA tmp dir must be set, as default is /tmp which won't
   # work with noexec constraints
   $jvm_options_defaults = [
-   "-Xms${es_heap_size}",
-   "-Xmx${es_heap_size}",
-   "-Djna.tmpdir=${::simp_elasticsearch::jna_tmpdir}"
+    "-Xms${es_heap_size}",
+    "-Xmx${es_heap_size}",
+    "-Djna.tmpdir=${::simp_elasticsearch::jna_tmpdir}"
   ]
 
   $_base_config = {

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,5 +1,5 @@
-# This class is just for storing default option hashes so the main
-# classes are cleaner.
+# This class is just for storing default option hashes/arrays so the
+# main classes are cleaner.
 #
 # Items are called from simp_elasticsearch
 #
@@ -24,7 +24,13 @@ class simp_elasticsearch::defaults {
     $es_heap_size = (( $mem_bytes / 2 ) + 2147483648 )
   }
 
-  $jvm_options_defaults = [ "-Xms${es_heap_size}", "-Xmx${es_heap_size}"  ]
+  # JNA tmp dir must be set, as default is /tmp which won't
+  # work with noexec constraints
+  $jvm_options_defaults = [
+   "-Xms${es_heap_size}",
+   "-Xmx${es_heap_size}",
+   "-Djna.tmpdir=${::simp_elasticsearch::jna_tmpdir}"
+  ]
 
   $_base_config = {
     'cluster'     => {
@@ -36,7 +42,7 @@ class simp_elasticsearch::defaults {
       # This must be done due to a bug in the ES configuration processor that
       # does not match the documentation which states that publish_host will be
       # automatically selected from the best address in bind_host.
-      # TODO Verify this workaround is still required with ES 5.3
+      # TODO Verify this workaround is still required with ES 5.X
       'publish_host' => $::simp_elasticsearch::bind_host
     },
     'http'        => {

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -13,11 +13,11 @@ class simp_elasticsearch::defaults {
   }
 
   # The amount of memory that ES should allocate on startup.
-  #   Default: 50% of Memory + 2G. If < 4G is present, just 50% of
+  #   Default: 50% of Memory + 2G. If < 10G is present, just 50% of
   #   mem.
   $mem_bytes = to_bytes($::memorysize)
 
-  if $mem_bytes < 4294967296 {
+  if $mem_bytes < 10737418240 {
     $es_heap_size = ( $mem_bytes / 2 )
   }
   else {

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,4 +1,4 @@
-# This class is just for storing default option hashes so the the main
+# This class is just for storing default option hashes so the main
 # classes are cleaner.
 #
 # Items are called from simp_elasticsearch
@@ -12,40 +12,31 @@ class simp_elasticsearch::defaults {
     $min_master_nodes = $::simp_elasticsearch::min_master_nodes
   }
 
-  if empty($::simp_elasticsearch::init_defaults['es_heap_size']) {
-    $mem_bytes = to_bytes($::memorysize)
+  # The amount of memory that ES should allocate on startup.
+  #   Default: 50% of Memory + 2G. If < 4G is present, just 50% of
+  #   mem.
+  $mem_bytes = to_bytes($::memorysize)
 
-    if $mem_bytes < 4294967296 {
-      $es_heap_size = ( $mem_bytes / 2 )
-    }
-    else {
-      $es_heap_size = (( $mem_bytes / 2 ) + 2147483648 )
-    }
+  if $mem_bytes < 4294967296 {
+    $es_heap_size = ( $mem_bytes / 2 )
+  }
+  else {
+    $es_heap_size = (( $mem_bytes / 2 ) + 2147483648 )
   }
 
-  $init_defaults = {
-    'ES_USER'      => 'elasticsearch',
-    'ES_GROUP'     => 'elasticsearch',
-    # The amount of memory that ES should allocate on startup.
-    #   Default: 50% of Memory + 2G. If < 4G is present, just 50% of
-    #   mem.
-    'ES_HEAP_SIZE' => $es_heap_size
-  }
+  $jvm_options_defaults = [ "-Xms${es_heap_size}", "-Xmx${es_heap_size}"  ]
 
-  $base_config = {
+  $_base_config = {
     'cluster'     => {
       'name'                => $::simp_elasticsearch::cluster_name
     },
     'node.name'   => $::simp_elasticsearch::node_name,
-    'index'       => {
-      'number_of_replicas'  => $::simp_elasticsearch::replicas,
-      'number_of_shards'    => $::simp_elasticsearch::shards
-    },
     'network'     => {
       'bind_host'    => $::simp_elasticsearch::bind_host,
       # This must be done due to a bug in the ES configuration processor that
       # does not match the documentation which states that publish_host will be
       # automatically selected from the best address in bind_host.
+      # TODO Verify this workaround is still required with ES 5.3
       'publish_host' => $::simp_elasticsearch::bind_host
     },
     'http'        => {
@@ -58,14 +49,20 @@ class simp_elasticsearch::defaults {
       'zen'                    => {
         'minimum_master_nodes' => $min_master_nodes,
         'ping'                 => {
-          'multicast'          => {
-            'enabled'          => false
-          },
           'unicast' => {
             'hosts' => $::simp_elasticsearch::unicast_hosts
           }
         }
       }
     }
+  }
+
+  if (versioncmp($facts['os']['release']['major'],'7') < 0) {
+    # CentOS 6 does not support SecComp so need to disable that feature
+    # See https://github.com/elastic/elasticsearch/issues/22899
+    $base_config  = merge($_base_config, { 'bootstrap.system_call_filter' => false })
+  }
+  else {
+    $base_config = $_base_config
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,7 @@
 # }
 #
 # @example ES instance on EL6
-# 
+#
 # In addition to the class definitions listed in the EL7 examples,
 # the following hieradata setting is required to ensure the
 # correct version of JAVA is installed:
@@ -157,7 +157,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_elasticsearch (
   String                          $cluster_name,
   Simplib::Host                   $node_name              = $facts['fqdn'],
@@ -177,15 +176,12 @@ class simp_elasticsearch (
   Integer                         $rolling_file_max_backup_index = 1,
   String                          $rolling_file_max_file_size    = '10MB',
   Data                            $es_config              = {},
-  String                          $max_locked_memory      = '',
-  String                          $max_open_files         = '',
   Variant[Boolean,Enum['conf']]   $manage_httpd           = true,
   Boolean                         $restart_on_change      = true,
   Optional[Boolean]               $restart_config_change  = undef,
   Optional[Boolean]               $restart_package_change = undef,
   Optional[Boolean]               $restart_plugin_change  = undef,
   Boolean                         $firewall               = simplib::lookup('simp_options::firewall', { 'default_value' => false}),
-  Boolean                         $install_unix_utils     = true,
   Boolean                         $spawn_default_instance = true,
 ) {
   include '::simp_elasticsearch::defaults'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
-# This class integrates the electrical-elasticsearch module with the
-# configuration settings recommended for SIMP systems.
+# This class integrates the elastic-elasticsearch module with
+# the configuration settings recommended for SIMP systems.
 #
 # Please use the portions that make sense for your environment.
 #
@@ -20,23 +20,22 @@
 # @param cluster_name *Required* The name of the cluster that this
 #   node will be joining.
 #
-# @param replicas The number of replicas for the ES cluster.
+# @param node_name An arbitrary, unique name for this node.
 #
-# @param shards The number of shards for the ES cluster.
-#
-# @param node_name An arbitrary, unique name fo this node.
-#
-# @param bind_host The IP address to which to bind the cluster
+# @param bind_host The IP address to which to bind the ES cluster
 #   communications service.
 #
-#   @note Do NOT set this to 127.0.0.1 unless you *really* know what you are
-#     doing.
+#   @note When set to 127.0.0.1 no cluster communication with external
+#     nodes is possible.
 #
 # @param http_bind_host The IP address to which to bind the http
 #   service.
 #
-#   @note Do NOT set this to 127.0.0.1 unless you *really* know what you are
-#     doing.
+#   @note For the most secure http configuration, set this to
+#     127.0.0.1, http_port to any value but 9200, and http_method_acl
+#     appropriately.  This will proxy http interactions into the
+#     ES engine with the authentication and/or command restrictions
+#     specified in http_method_acl.
 #
 # @param http_port This port will be exposed for http interactions into
 #   the ES engine.
@@ -45,16 +44,14 @@
 #     9200. 9200 is the ES default so setting this to *anything else* means
 #     that you want to proxy and to not expose this port to the world.
 #
+# @param http_timeout  Default timeout (in seconds) to use when accessing
+#     Elasticsearch APIs.
+#
 # @param http_method_acl This controls the remote accesses allowed to
 #   ES. This is quite complex and you should check the documentation carefully
 #   prior to proceeding.
 #
 #     @see simp_elasticsearch::apache option 'method_acl'
-#
-# @param https_trusted_nets This is an array of IPs/hosts to
-#   allow to connect to the https service. If you're using ES for LogStash,
-#   then all clients that should be able to connect to this node in order to
-#   store data into ES should be allowed.
 #
 # @param data_dir The path where the data should be stored.  You
 #   will need to create all parent directories, this module will not do it for
@@ -66,27 +63,32 @@
 #   @note If fewer than 3 unicast hosts are specified below, this will default
 #     to 1.
 #
-# @param unicast_hosts We do not support multicast joining
-#   for security reasons. You must specify all of your hosts here.
-#
-#   @note It not recommended to change this default unless you have a different
-#     Hiera variable that you are using.
+# @param unicast_hosts You must specify all of your hosts here.
 #
 # @param init_defaults Options that will be passed directly into
-#   /etc/sysconfig/elasticsearch. Anything passed in via this hash will be
-#   merged with the default hash.
+#   the sysconfig file for the elasticsearch service.
+#
+# @param jvm_options JVM options to be persisted to /etc/elasticsearch/jvm.options.
+#   Anything passed in via this array will be appended to the default options.
 #
 # @param es_config Options as required by the 'elasticsearch'
 #   module.  If you specify your own hash, then it will be merged with the
 #   default.
 #
-# @param max_log_days The number of days of elasticsearch logs to keep
-#   on the system.
+# @param file_rolling_type Configuration for the file appender rotation.
+#   It can be 'dailyRollingFile' to rotate by name or 'rollingFile' to
+#   to rotate by name by size.
 #
-#   @note This will *not* remove files by size so watch your cluster disk space
-#     in /var/log.
+# @param daily_rolling_date_pattern File pattern for the file appender
+#   log when file_rolling_type is 'dailyRollingFile'.
 #
-# @param manage_httpd Whether or not to manage the httpd configuration
+# @param rolling_file_max_backup_index Max number of logs to store when
+#   file_rolling_type is 'rollingFile'.
+#
+# @param rolling_file_max_file_size Max log file size when file_rolling_type
+#    is 'rollingFile'.
+#
+# @param manage_httpd Whether to manage the httpd configuration
 #   on this system.
 #
 #   May be One of `true`, `false`, or 'conf'
@@ -96,34 +98,62 @@
 #       note:  conf assumes you have apache installed and that Service['httpd'] exists
 #              somewhere in the catalog.
 #
-# @param restart_on_change Whether or not to restart on a
-#   configuration change.
+# @param restart_on_change  Whether to automatically restart ES whenever the
+#   configuration, package, or plugins change. This may be undesireable in
+#   highly available environments.  If all other restart_* parameters are
+#   left unset, the value of restart_on_change is used for all other
+#   restart_*_change defaults.
 #
-# @param firewall Whether or not to use iptables for ES
-#   connections.
+# @param restart_config_change  Whether to automatically restart ES
+#   whenever the configuration changes. Disabling automatic restarts on
+#   config changes may be desired in an environment where you need to
+#   ensure restarts occur in a controlled/rolling manner rather than
+#   during a Puppet run.
 #
-# @param spawn_default_instance  If set, create a default instance,
-#   named 'simp', on the system.
+# @param restart_package_change  Whether to automatically restart ES
+#   whenever the package (or package version) for ES changes.  Disabling
+#   automatic restarts on package changes may be desired in an
+#   environment where you need to ensure restarts occur in a
+#   controlled/rolling manner rather than during a Puppet run.
 #
-# @example Local ES instance
+# @param restart_plugin_change  Whether to automatically restart ES
+#   whenever plugins are installed or removed.  Disabling automatic
+#   restarts on plugin changes may be desired in an environment where
+#   you need to ensure restarts occur in a controlled/rolling manner
+#   rather than during a Puppet run.
+#
+# @param firewall Whether to use iptables for ES http connections
+#   and cluster communications.
+#
+# @param spawn_default_instance  If set, create a default ES instance,
+#   named for the cluster, on the system.
+#
+# @example Local ES instance EL7
 #
 # # Set up an ES instance that will only run on this server.
-# # No entry added to the extdata directory
 #
 # class { 'simp_elasticsearch': cluster_name => 'single' }
 #
-# @example Clustered ES instance
+# @example Clustered ES instance EL7
 #
 # # Set up an ES instance that will act as part of a larger cluster.
-# # An entry in Hiera must be set to the following:
-# FIXME
-# # simp_elasticsearch,"<ip_address_one>","<ip_address_two>"
 #
 # class { 'simp_elasticsearch':
-#   cluster_name        => 'multi',
-#   number_of_replicas  => 2,
-#   number_of_shards    => 8
+#   cluster_name  => 'multi',
+#   unicast_hosts => {
+#    'first.cluster.host:9300',
+#    'second.cluster.host:9300',
+#    'third.cluster.host:9300',
+#   },
 # }
+#
+# @example ES instance on EL6
+# 
+# In addition to the class definitions listed in the EL7 examples,
+# the following hieradata setting is required to ensure the
+# correct version of JAVA is installed:
+#
+# java::package : 'java-1.8.0-openjdk-devel'
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
@@ -131,23 +161,29 @@
 class simp_elasticsearch (
   String                          $cluster_name,
   Simplib::Host                   $node_name              = $facts['fqdn'],
-  Integer[0]                      $replicas               = 1,
-  Integer[0]                      $shards                 = 5,
   Simplib::Host                   $bind_host              = $facts['ipaddress'],
   Simplib::Host                   $http_bind_host         = '127.0.0.1',
   Simplib::Port                   $http_port              = 9199,
+  Integer                         $http_timeout           = 10,
   Hash                            $http_method_acl        = {},
   Stdlib::AbsolutePath            $data_dir               = '/var/elasticsearch',
   Integer[0]                      $min_master_nodes       = 2,
   Array[Simplib::Host::Port]      $unicast_hosts          = ["${facts['fqdn']}:9300"],
   Hash[Pattern['^[A-Z,_]+$'],Any] $init_defaults          = {},
+  Array[Pattern['^-']]            $jvm_options            = [],
+  Enum['dailyRollingFile',
+    'rollingFile']                $file_rolling_type             = 'dailyRollingFile',
+  String                          $daily_rolling_date_pattern    = '"\'.\'yyyy-MM-dd"',
+  Integer                         $rolling_file_max_backup_index = 1,
+  String                          $rolling_file_max_file_size    = '10MB',
   Data                            $es_config              = {},
-  Numeric                         $max_log_days           = 7,
   String                          $max_locked_memory      = '',
   String                          $max_open_files         = '',
   Variant[Boolean,Enum['conf']]   $manage_httpd           = true,
-  Simplib::NetList                $https_trusted_nets     = ['127.0.0.1'],
   Boolean                         $restart_on_change      = true,
+  Optional[Boolean]               $restart_config_change  = undef,
+  Optional[Boolean]               $restart_package_change = undef,
+  Optional[Boolean]               $restart_plugin_change  = undef,
   Boolean                         $firewall               = simplib::lookup('simp_options::firewall', { 'default_value' => false}),
   Boolean                         $install_unix_utils     = true,
   Boolean                         $spawn_default_instance = true,
@@ -162,41 +198,49 @@ class simp_elasticsearch (
     $_config = $::simp_elasticsearch::defaults::base_config
   }
 
+
   if $spawn_default_instance {
+    $default_instance_name = es_systemd_escape($cluster_name)
     include '::simp_elasticsearch::default_instance'
 
     Class['simp_elasticsearch'] -> Class['simp_elasticsearch::default_instance']
+    $_service_name = "elasticsearch-${default_instance_name}.service"
   }
+  else {
+    $_service_name = 'elasticsearch.service'
+  }
+
 
   include '::java'
 
   # TODO: Figure out how to move this into a single include!
   class { 'elasticsearch':
-    config            => $_config,
-    autoupgrade       => true,
-    status            => 'enabled',
-    init_defaults     => deep_merge(
-      $init_defaults,
-      $::simp_elasticsearch::defaults::init_defaults
+    config                        => $_config,
+    autoupgrade                   => true,
+    status                        => 'enabled',
+    init_defaults                 => $init_defaults,
+    jvm_options                   => concat(
+      $::simp_elasticsearch::defaults::jvm_options_defaults,
+      $jvm_options
     ),
-    datadir           => "${data_dir}/data",
-    restart_on_change => $restart_on_change
+    datadir                       => "${data_dir}/data",
+    restart_on_change             => $restart_on_change,
+    restart_config_change         => $restart_config_change,
+    restart_package_change        => $restart_package_change,
+    restart_plugin_change         => $restart_plugin_change,
+    file_rolling_type             => $file_rolling_type,
+    daily_rolling_date_pattern    => $daily_rolling_date_pattern,
+    rolling_file_max_backup_index => $rolling_file_max_backup_index,
+    rolling_file_max_file_size    => $rolling_file_max_file_size,
+    api_host                      => $http_bind_host,
+    api_port                      => $http_port,
+    api_timeout                   => $http_timeout
   }
 
   Class['java'] -> Class['elasticsearch']
 
-  file { '/etc/cron.daily/elasticsearch_log_purge':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0700',
-    content => "#!/bin/sh
-if [ -d /var/log/elasticsearch ]; then
-  /bin/find /var/log/elasticsearch -type f -mtime +${max_log_days} -exec /bin/rm {} \\;
-fi
-"
-  }
-
   # Correct the permissions on the ES templates directory
+  # TODO Verify this workaround is still required.
   file { '/etc/elasticsearch/templates_import':
     ensure => directory,
     owner  => 'root',
@@ -212,6 +256,7 @@ fi
   }
 
   # This is here due to some weird bug in ES that won't read /etc properly.
+  # TODO Verify this workaround is still required.
   file { '/usr/share/elasticsearch/config':
     ensure => 'symlink',
     target => '/etc/elasticsearch',
@@ -227,10 +272,12 @@ fi
     }
   }
 
+  $_http_listen_port = 9200
   if $manage_httpd or $manage_httpd == 'conf' {
     class { 'simp_elasticsearch::simp_apache':
       manage_httpd => $manage_httpd,
-      proxyport    => $_config['http']['port'],
+      listen       => $_http_listen_port,
+      proxy_port   => $_config['http']['port'],
       method_acl   => $http_method_acl,
     }
   }
@@ -245,7 +292,7 @@ fi
           if defined('$_macl_hosts') and !empty($_macl_hosts) {
             iptables::listen::tcp_stateful{ 'elasticsearch_allow_remote':
               trusted_nets => keys($_macl_hosts),
-              dports       => [ 9200 ]
+              dports       => [ $_http_listen_port ]
             }
           }
         }
@@ -259,5 +306,33 @@ fi
     item    => 'memlock',
     value   => 'unlimited',
     order   => 0,
+  }
+
+  # Make sure elasticsearch user can spawn up to 2048 threads
+  if (versioncmp($facts['os']['release']['major'],'7') < 0) {
+    # see man page for limits.conf
+    pam::limits::rule { 'es_nproc':
+      domains => ['elasticsearch'],
+      item    => 'nproc',
+      value   => 2048,
+    }
+  }
+  else {
+    # see man page for systemd.unit
+    $_systemd_opts_dir = "/etc/systemd/system/${_service_name}.d"
+    file { $_systemd_opts_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+    }
+
+    file { "${_systemd_opts_dir}/opts.conf":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => file("${module_name}/opts.conf"),
+    }
   }
 }

--- a/manifests/pki.pp
+++ b/manifests/pki.pp
@@ -36,6 +36,12 @@
 # @param app_pki_ca_dir
 #   Path to the CA.
 #
+# @param group
+#   Group for PKI copies
+#
+# @param owner
+#   Owner for PKI copies
+#
 class simp_elasticsearch::pki(
   Variant[Boolean,Enum['simp']] $pki                     = simplib::lookup('simp_options::pki' , { 'default_value' => false }),
   Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),

--- a/manifests/simp_apache.pp
+++ b/manifests/simp_apache.pp
@@ -2,7 +2,7 @@
 # ElasticSearch. The defaults are targeted toward making the interface as
 # highly available as possible without regard to system load.
 #
-# @param manage_http Whether or not to manage the httpd daemon/apache
+# @param manage_httpd Whether or not to manage the httpd daemon/apache
 #   itself.
 #
 #   @note This class assumes that you're using the simp-supplied apache module
@@ -13,6 +13,19 @@
 #
 # @param proxy_port The port to proxy HTTP connections to on the local
 #   system.
+#
+# @param cipher_suite OpenSSL cipher suite to use for SSL connections
+#
+# @param ssl_protocols  SSL protocols allowed
+#
+# @param apache_user  apache user; used to set configuration file ownership
+#
+# @param apache_group  apache group; used to set configuration file ownership
+#
+# @param ssl_verify_client Type of client certificate verification.
+#
+# @param ssl_verify_depth  Maximum depth of CA certificates in client
+#   certificate verifiction.
 #
 # @param method_acl Users, Groups, and Hosts HTTP operation ACL
 #   management. Keys are the relevant entry to allow and values are an Array of
@@ -97,19 +110,18 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
-#
 class simp_elasticsearch::simp_apache (
-  Variant[Boolean,Enum['conf']]  $manage_httpd,
-  Simplib::Port                  $listen            = 9200,
-  Simplib::Port                  $proxy_port        = 9199,
-  Array[String]                  $cipher_suite      = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['HIGH'] } ),
-  Array[String]                  $ssl_protocols     = ['+TLSv1','+TLSv1.1','+TLSv1.2'],
-  String                         $apache_user       = 'root',
-  String                         $apache_group      = 'apache',
-  String                         $ssl_verify_client = 'require',
-  Integer                        $ssl_verify_depth  = 10,
-  Hash                           $method_acl        = {},
+  Variant[Boolean,Enum['conf']]    $manage_httpd,
+  Simplib::Port                    $listen            = 9200,
+  Simplib::Port                    $proxy_port        = 9199,
+  Array[String]                    $cipher_suite      = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['HIGH'] } ),
+  Array[String]                    $ssl_protocols     = ['+TLSv1','+TLSv1.1','+TLSv1.2'],
+  String                           $apache_user       = 'root',
+  String                           $apache_group      = 'apache',
+  Enum['none', 'require',
+    'optional', 'optional_no_ca']  $ssl_verify_client = 'require',
+  Integer                          $ssl_verify_depth  = 10,
+  Hash                             $method_acl        = {},
 ) {
 
   if $manage_httpd or $manage_httpd == 'conf' {

--- a/manifests/simp_apache.pp
+++ b/manifests/simp_apache.pp
@@ -102,7 +102,7 @@
 class simp_elasticsearch::simp_apache (
   Variant[Boolean,Enum['conf']]  $manage_httpd,
   Simplib::Port                  $listen            = 9200,
-  Simplib::Port                  $proxyport         = 9199,
+  Simplib::Port                  $proxy_port        = 9199,
   Array[String]                  $cipher_suite      = simplib::lookup('simp_options::openssl::cipher_suite', { 'default_value' => ['HIGH'] } ),
   Array[String]                  $ssl_protocols     = ['+TLSv1','+TLSv1.1','+TLSv1.2'],
   String                         $apache_user       = 'root',

--- a/manifests/simp_apache/defaults.pp
+++ b/manifests/simp_apache/defaults.pp
@@ -3,8 +3,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
-#
 class simp_elasticsearch::simp_apache::defaults {
 
   $_base_dn = simplib::lookup('simp_options::ldap::base_dn', { 'default_value' => '' })

--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": [
     {
-      "name": "elasticsearch/elasticsearch",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "name": "elastic/elasticsearch",
+      "version_requirement": ">= 5.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "elasticsearch/elasticsearch",
-      "version_requirement": ">= 0.11.0 < 1.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -59,10 +59,6 @@
     {
       "name": "puppet",
       "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
     }
   ],
   "data_provider": "hiera"

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,10 +11,10 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       simp:
-        baseurl: https://dl.bintray.com/simp/5.1.X
+        baseurl: https://packagecloud.io/simp-project/6_X/el/7/x86_64
         gpgcheck: 0
       elasticsearch:
-        baseurl: 'https://packages.elastic.co/elasticsearch/2.x/centos'
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
         gpgcheck: 0
 
   el6-server:
@@ -26,10 +26,10 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       simp:
-        baseurl: https://dl.bintray.com/simp/4.2.X
+        baseurl: https://packagecloud.io/simp-project/6_X/el/6/x86_64
         gpgcheck: 0
       elasticsearch:
-        baseurl: 'https://packages.elastic.co/elasticsearch/2.x/centos'
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
         gpgcheck: 0
 
 CONFIG:

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -35,7 +35,7 @@ include '::simp_elasticsearch'
 simp_elasticsearch::cluster_name : 'test_cluster'
 simp_elasticsearch::bind_host : '#IPADDRESS#'
 simp_elasticsearch::unicast_hosts :
-  - #{hosts.map{|x| x.to_s + ':9300'}.join("\n  - ")}
+  - #{hosts.map{|x| '"' + x.to_s + '.%{::domain}' + ':9300"'}.join("\n  - ")}
 
 simp_elasticsearch::http_method_acl :
   limits :

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -15,14 +15,19 @@ describe 'simp_elasticsearch class' do
       pattern => 'ALL'
     }
 
-    iptables::listen::tcp_stateful { 'i_love_testing':
+    iptables::listen::tcp_stateful { 'ssh_access':
       order        => 8,
       trusted_nets => ['10.0.0.0/16','127.0.0.0/2'],
       dports       => 22
     }
   EOM
+ 
+  let(:manifest) { <<-EOM
+include '::simp_elasticsearch'
 
-  let(:manifest) { "include '::simp_elasticsearch'" }
+#{ssh_allow}
+  EOM
+  }
 
   let(:hieradata) {
     <<-EOS
@@ -32,6 +37,11 @@ simp_elasticsearch::bind_host : '#IPADDRESS#'
 simp_elasticsearch::unicast_hosts :
   - #{hosts.map{|x| x.to_s + ':9300'}.join("\n  - ")}
 
+simp_elasticsearch::http_method_acl :
+  limits :
+    hosts :
+      #{hosts.map{|x| '"' + x.to_s + '.%{::domain}" : defaults'}.join("\n      ")}
+
 simp_apache::rsync_web_root : false
 simp_options::rsync::server : "%{::fqdn}"
 
@@ -39,7 +49,7 @@ simp_options::pki : true
 simp_options::pki::source : '/etc/pki/simp-testing/pki'
 
 simp_options::firewall : true
-    EOS
+   EOS
   }
 
   elasticsearch_servers.each do |host|
@@ -54,6 +64,11 @@ simp_options::firewall : true
 
         hdata = hieradata.dup
         hdata.gsub!(/#IPADDRESS#/m, ipaddr)
+
+        if host.name == 'el6-server'
+          # need newer JAVA version 
+           hdata += "\njava::package : 'java-1.8.0-openjdk-devel'\n"
+        end
 
         set_hieradata_on(host, hdata)
         apply_manifest_on(host, manifest, :catch_failures => true)
@@ -77,7 +92,18 @@ simp_options::firewall : true
       sleep(30)
 
       result = on(host, %(curl -XGET 'http://localhost:9199/_cat/nodes')).stdout
-      result.lines.count.should eql(elasticsearch_servers.count)
+      expect(result.lines.count).to eq elasticsearch_servers.count
+    end
+
+    it 'should allow secure ES api access' do
+      fqdn = fact_on(host, 'fqdn')
+      cert = "/etc/pki/simp_apps/simp_apache/x509/private/#{fqdn}.pem"
+      elasticsearch_servers.each do |es_host|
+        # -k needed because we are using a self-signing CA
+        # --cert needed because SSLVerifyClient is enabled by default in ES apache config
+        result = on(host, %(curl -k --cert #{cert} -XGET 'https://#{es_host.name}:9200/_cat/nodes')).stdout
+        expect(result.lines.count).to eq elasticsearch_servers.count
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 shared_examples_for 'a simp_elasticsearch profile' do |os_release_major, service_name|
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to create_class('simp_elasticsearch') }
+  it { is_expected.to create_class('simp_elasticsearch::config') }
   it { is_expected.to create_class('pam::limits') }
   it { is_expected.to create_class('java') }
   it { is_expected.to create_class('elasticsearch') }
@@ -10,6 +11,9 @@ shared_examples_for 'a simp_elasticsearch profile' do |os_release_major, service
   it { is_expected.to create_file('/var/elasticsearch/data') }
   it { is_expected.to create_file('/usr/share/elasticsearch/config') }
   it { is_expected.to create_pam__limits__rule('es_heap_sizelock') }
+  it { is_expected.to create_user('elasticsearch').with_home('/var/local/elasticsearch') }
+  it { is_expected.to create_file('/var/local/elasticsearch') }
+  it { is_expected.to create_file('/var/lib/elasticsearch/tmp') }
   if os_release_major == '6'
     it { is_expected.to contain_pam__limits__rule('es_nproc') }
   else

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,50 +1,164 @@
 require 'spec_helper'
 
+shared_examples_for 'a simp_elasticsearch profile' do |os_release_major, service_name|
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('simp_elasticsearch') }
+  it { is_expected.to create_class('pam::limits') }
+  it { is_expected.to create_class('java') }
+  it { is_expected.to create_class('elasticsearch') }
+  it { is_expected.to create_file('/etc/elasticsearch/templates_import') }
+  it { is_expected.to create_file('/var/elasticsearch/data') }
+  it { is_expected.to create_file('/usr/share/elasticsearch/config') }
+  it { is_expected.to create_pam__limits__rule('es_heap_sizelock') }
+  if os_release_major == '6'
+    it { is_expected.to contain_pam__limits__rule('es_nproc') }
+  else
+    it { is_expected.to create_file("/etc/systemd/system/#{service_name}.service.d") }
+    it { is_expected.to create_file("/etc/systemd/system/#{service_name}.service.d/opts.conf") }
+  end
+end
+
 describe 'simp_elasticsearch' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os} operating system" do
       let(:facts){ facts }
-      default_params = {
-        :cluster_name => 'es_cluster'
-      }
-      let(:conf_manifest) {
-       <<-EOM
-          service { 'httpd':
-            ensure => running,
+      let(:default_params) { { :cluster_name => 'es_cluster' } }
+      let(:default_es_config) { {
+        'cluster'   => { 'name' => 'es_cluster' },
+        'node.name' => facts[:fqdn],
+        'network'   => {
+          'bind_host'    => facts[:ipaddress],
+          'publish_host' => facts[:ipaddress]
+        },
+        'http'       => {
+         'bind_host' => '127.0.0.1',
+         'port'      => 9199
+        },
+        'path.logs'   => '/var/log/elasticsearch',
+        'path.data'   => '/var/elasticsearch',
+        'discovery'   => {
+          'zen'       => {
+            'minimum_master_nodes' => 1,
+            'ping'                 => {
+              'unicast' => {
+                'hosts' => [ "#{facts[:fqdn]}:9300" ]
+              }
+            }
           }
-        EOM
-      }
-
-      context "with default params" do
-        let(:params) {
-          default_params
         }
+      } }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('simp_elasticsearch') }
-        it { is_expected.to_not create_class('iptables') }
-        it { is_expected.to create_class('pam::limits') }
-        it { is_expected.to create_class('simp_apache') }
+      context 'with default params' do
+        let(:params) { default_params }
+
+        it_should_behave_like 'a simp_elasticsearch profile', facts[:os][:release][:major], 'elasticsearch-es_cluster'
+        it { 
+          expected_config = default_es_config
+          if facts[:os][:release][:major] < '7'
+            expected_config['bootstrap.system_call_filter'] = false
+          end
+          is_expected.to create_class('elasticsearch').with( {
+            :config      => expected_config
+          } )
+        }
+        it { is_expected.to create_elasticsearch__instance('es_cluster') }
         it { is_expected.to create_class('simp_elasticsearch::simp_apache') }
+        it { is_expected.to create_class('simp_apache') }
+        it { is_expected.to create_class('simp_apache::ssl') }
+        it { is_expected.to_not create_class('iptables') }
+        it { is_expected.to_not create_class('pki') }
       end
 
-     context "with manage_httpd and firewall" do
-       let(:params) do default_params.merge({
+      context "with manage_httpd='conf', http_method_acl={}, and firewall=true" do
+        let(:params) do default_params.merge({
             :manage_httpd => 'conf',
             :firewall     => true
           })
         end
-        let(:pre_condition) {'include simp_apache'}
         let(:hieradata) { 'pki' }
 
-        it { is_expected.to compile.with_all_deps }
+        it_should_behave_like 'a simp_elasticsearch profile', facts[:os][:release][:major], 'elasticsearch-es_cluster'
         it { is_expected.to create_class('simp_elasticsearch::pki')}
         it { is_expected.to create_pki__copy('simp_elasticsearch')}
         it { is_expected.to create_file('/etc/pki/simp_apps/simp_elasticsearch/x509')}
         it { is_expected.to contain_class('pki')}
         it { is_expected.to create_class('iptables') }
+        it { 
+          is_expected.to create_iptables_rule('elasticsearch_allow_cluster').with({
+            :content => "-s #{facts[:fqdn]} -p tcp -m state --state NEW -m tcp -m multiport --dports 9300 -j ACCEPT"
+          })
+        }
         it { is_expected.to create_class('simp_elasticsearch::simp_apache') }
-     end
+        it { is_expected.to_not create_iptables__listen__tcp_stateful('elasticsearch_allow_remote')}
+      end
+
+      context "with manage_httpd=true, http_method_acl with 'limits', and firewall=true"  do
+        let(:params) do default_params.merge({
+            :manage_httpd => true,
+            :http_method_acl => {
+              'limits' => {
+                'defaults' => [ 'GET', 'POST', 'PUT' ],
+                'hosts'  => {
+                  '1.2.3.4'     => 'defaults',
+                  '10.1.2.0/24' => 'defaults'
+                }
+              }
+            },
+            :firewall     => true
+          })
+        end
+        let(:hieradata) { 'pki' }
+
+        it_should_behave_like 'a simp_elasticsearch profile', facts[:os][:release][:major], 'elasticsearch-es_cluster'
+        it { 
+          is_expected.to create_iptables__listen__tcp_stateful('elasticsearch_allow_remote').with({
+            :trusted_nets => ['1.2.3.4', '10.1.2.0/24'],
+            :dports       => [ 9200 ]
+          })
+        }
+      end
+
+      context 'with manage_httpd=false and spawn_default_instance=false' do
+        let(:params) { default_params.merge({ 
+          :manage_httpd => false,
+          :spawn_default_instance => false
+        }) }
+
+        it_should_behave_like 'a simp_elasticsearch profile', facts[:os][:release][:major], 'elasticsearch'
+        it { is_expected.to_not create_elasticsearch__instance('es_cluster') }
+        it { is_expected.to_not create_class('simp_apache') }
+        it { is_expected.to_not create_class('simp_elasticsearch::simp_apache') }
+      end
+
+      context 'with custom ES config settings' do
+        let(:params) do default_params.merge({
+            :es_config => {
+              'http'       => {
+                'port'            => 4199,
+                'max_header_size' => 1000
+              },
+            }
+          })
+        end
+
+        it_should_behave_like 'a simp_elasticsearch profile', facts[:os][:release][:major], 'elasticsearch-es_cluster'
+        it 'should merge with default settings, replacing defaults and adding new settings' do
+          expected_config = default_es_config
+          expected_config['http']['port'] = 4199
+          expected_config['http']['max_header_size'] = 1000
+          if facts[:os][:release][:major] < '7'
+            expected_config['bootstrap.system_call_filter'] = false
+          end
+          is_expected.to create_class('elasticsearch').with( {
+            :config      => expected_config
+          } )
+        end
+
+        it 'should use replaced ES port setting in elasticsearch httpd config' do
+          is_expected.to create_simp_apache__site('elasticsearch').with_content(
+            %r{   BalancerMember http://127.0.0.1:4199 max=1 retry=5})
+        end
+      end
 
     end
   end

--- a/spec/classes/simp_apache_spec.rb
+++ b/spec/classes/simp_apache_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+
+shared_examples_for 'a simp_elasticsearch::simp_apache' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch') }
+  it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch/auth') }
+  it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch/limit') }
+end
+
+describe 'simp_elasticsearch::simp_apache' do
+  on_supported_os.each do |os, facts|
+    context "on #{os} operating system" do
+      let(:facts){ facts }
+
+      context 'with default params and manage_httpd=true' do
+        let(:params) { { :manage_httpd => true } }
+
+        it_should_behave_like 'a simp_elasticsearch::simp_apache'
+        it { is_expected.to create_class('simp_apache') }
+        it { is_expected.to create_class('simp_apache::ssl') }
+        it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch/limit/limits.conf').with_content( <<EOM
+<Limit GET>
+  Order allow,deny
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+<Limit POST>
+  Order allow,deny
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+<Limit PUT>
+  Order allow,deny
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+EOM
+        ) }
+
+        it { is_expected.to create_simp_apache__site('elasticsearch').with_content( <<EOM
+# This file managed by Puppet
+
+Listen 9200
+
+# Doing this to keep out of the way of other Apache configurations.
+<VirtualHost *:9200>
+
+  SSLEngine on
+
+  SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2
+  SSLCipherSuite HIGH
+  SSLCertificateFile /etc/pki/simp_apps/simp_apache/x509/public/foo.example.com.pub
+  SSLCertificateKeyFile /etc/pki/simp_apps/simp_apache/x509/private/foo.example.com.pem
+  SSLCACertificatePath /etc/pki/simp_apps/simp_apache/x509/cacerts
+
+  SSLVerifyClient require
+  SSLVerifyDepth 10
+
+  <Proxy balancer://main>
+    BalancerMember http://127.0.0.1:9199 max=1 retry=5
+
+    <IfVersion < 2.4>
+    include '/etc/httpd/conf.d/elasticsearch/auth/*.conf'
+    </IfVersion>
+    <IfVersion >= 2.4>
+    IncludeOptional '/etc/httpd/conf.d/elasticsearch/auth/*.conf'
+    </IfVersion>
+
+    # Restrict who can write to ES.
+    include '/etc/httpd/conf.d/elasticsearch/limit/*.conf'
+
+    <LimitExcept GET POST PUT>
+      Order allow,deny
+    </LimitExcept>
+  </Proxy>
+
+  ProxyPass / balancer://main/
+  ProxyPassReverse / balancer://main/
+</VirtualHost>
+EOM
+        ) }
+      end
+
+      context "with manage_httpd='conf' and method_acl set" do
+        let(:params) { {
+          :manage_httpd => 'conf',
+          :method_acl => {
+            'method' => {
+              'ldap'     => {
+                'enable'      => true
+              }
+            },
+            'limits' => {
+              'defaults' => [ 'GET', 'POST', 'PUT' ],
+              'hosts'    => {
+                '1.2.3.4'     => 'defaults',
+                '10.1.2.0/24' => 'defaults'
+              }
+            }
+          }
+        } }
+        let(:hieradata) { 'ldap' }
+
+        it_should_behave_like 'a simp_elasticsearch::simp_apache'
+        it { is_expected.to create_class('simp_elasticsearch::pki') }
+        it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch/limit/limits.conf').with_content( <<EOM
+<Limit GET>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+<Limit POST>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+<Limit PUT>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 127.0.0.1
+  Allow from foo.example.com
+  Require all denied
+  Satisfy any
+</Limit>
+EOM
+        ) }
+
+        it { is_expected.to create_simp_apache__site('elasticsearch') }
+  it { is_expected.to create_file('/etc/httpd/conf.d/elasticsearch/auth/auth.conf').with_content( <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider ldap
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=example,dc=com" STARTTLS
+AuthLDAPBindDN "cn=hostAuth,ou=People,dc=example,dc=com"
+AuthLDAPBindPassword 'B1nd=P@ssw0rd=F0r=T3st'
+AuthLDAPGroupAttributeIsDN off
+AuthLDAPGroupAttribute memberUid
+EOM
+  ) }
+      end
+
+    end
+  end
+end

--- a/spec/fixtures/hieradata/ldap.yaml
+++ b/spec/fixtures/hieradata/ldap.yaml
@@ -1,0 +1,7 @@
+---
+simp_options::ldap::uri:
+- 'ldap://server1'
+- 'ldap://server2'
+simp_options::ldap::base_dn: 'dc=example,dc=com'
+simp_options::ldap::bind_dn: 'cn=hostAuth,ou=People,dc=example,dc=com'
+simp_options::ldap::bind_pw: 'B1nd=P@ssw0rd=F0r=T3st'

--- a/spec/functions/es_systemd_escape_spec.rb
+++ b/spec/functions/es_systemd_escape_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'es_systemd_escape' do
+  testcases = {
+    'hello, world'    => 'hello\x2c\x20world',
+    '/some/file/path' => '-some-file-path',
+    'a/b'             => 'a-b',
+    'my-cluster'      => 'my\x2dcluster',
+    'your_cluster'    => 'your_cluster',
+    'their.cluster'   => 'their.cluster',
+    'odd@!#$%&()*+,\/:;<=>?[]^{}|\~' =>
+      'odd\x40\x21\x23\x24\x25\x26\x28\x29\x2a\x2b\x2c\x5c-:\x3b\x3c\x3d\x3e\x3f\x5b\x5d\x5e\x7b\x7d\x7c\x5c\x7e'
+  }
+
+  context "with valid input" do
+    testcases.each do |input, expected_output|
+      it { is_expected.to run.with_params(input).and_return(expected_output) }
+    end
+  end
+
+  context 'with invalid input' do
+    it { is_expected.to run.with_params().and_raise_error(ArgumentError, /Wrong number of arguments/i) }
+
+    it {
+      is_expected.to run.with_params(1).and_raise_error(Puppet::ParseError,
+       /Expects a string argument, got 1 which is of type Fixnum/i)
+    }
+  end
+end
+

--- a/templates/simp/etc/httpd/conf.d/elasticsearch.conf.erb
+++ b/templates/simp/etc/httpd/conf.d/elasticsearch.conf.erb
@@ -17,7 +17,7 @@ Listen <%= @listen %>
   SSLVerifyDepth <%= @ssl_verify_depth %>
 
   <Proxy balancer://main>
-    BalancerMember http://127.0.0.1:9199 max=1 retry=5
+    BalancerMember http://127.0.0.1:<%= @proxy_port %> max=1 retry=5
 
     <IfVersion < 2.4>
     include '<%= @es_httpd_includes %>/auth/*.conf'


### PR DESCRIPTION
WORK ACCOMPLISHED:
- Eliminate sysconfig init defaults.
  - No longer need to add ES_USER and ES_GROUP.
  - ES_HEAP_SIZE is no longer supported as a sysconfig item,  or
    elasticsearch will fail to start if present.  Instead, we
    configure this in jvm.options
- Set heap size in jvm.options file, as ES_HEAP_SIZE environment
  variable is no longer supported by ES
- Set maximum number of threads via the nproc setting.
  Default value was too low and ES failed to start.
- Remove shards and replicas from node settings, as they
  must now be set per index.  ES failed to start with the
  old setting.
- Remove discovery.zen.ping.multicast.enabled node setting,
  since multicast support has been removed from ES.
- Updated repository for ES packages.  New repository is
  now at https://artifacts.elastic.co.
- Disabled ES use of sycall filter on EL6, as it is not
  supported by EL6
- Add following configuration parameters:
  $jvm_options
  $restart_config_change
  $restart_package_change
  $restart_plugin_change
  $jvm_options = undef
  $file_rolling_type
  $daily_rolling_date_pattern
  $rolling_file_max_backup_index
  $rolling_file_max_file_size
  $http_timeout
- Remove following configuration parameters:
  $plugintool - No longer supported by elastic/puppet-elasticsearch
  $max_log_days - No longer needed now that rolling log file support
    has been added to elastic/puppet-elasticsearch
  $https_trusted_nets - Not used
- Removed init_defaults, as is no longer needed
- Remove elasticsearch_log_purge cron job, as it is no longer needed.
- Change name of default ES instance to contain cluster name,
  instead of generic 'simp'.
- Used proxy_port parameter in elasticsearch.conf.erb, instead of hardcoding
  the port to 9199.
- Updated documentation
- Expanded tests

WORK NOT DONE:
- Restructure software to eliminate the circular relationship between
  parameters in init.pp and those in defaults.pp.
- Use the settings keystore for secure configuration (see
  https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-settings.html)