### PR TITLE
(SIMP-3372) simp_elasticsearch - changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,11 +8,11 @@
 * Wed Feb 01 2017 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.0-0
 - All hiera() lookups changed to lookup() or simplib::lookup()
 
-* Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com>  5.0.0-0
+* Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com>  4.1.1-0
 - Updated pki scheme
 - Application certs now managed in /etc/pki/simp_apps/simp_elasticsearch/x509
 
-* Fri Dec 30 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.0-0
+* Fri Dec 30 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.1.1-0
 - Cleaned up the manage_httpd logic
 
 * Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,18 @@
 * Fri Jun 16 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Update custom Puppet 3 functions to namespaced, Puppet 4 functions
+- Update puppet requirement and remove OBE pe requirement in metadata.json
 
 * Wed Apr 26 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Update to work with Elasticsearch 5.3
 
-* Wed Feb 01 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.1-0
+* Wed Feb 01 2017 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.0-0
 - All hiera() lookups changed to lookup() or simplib::lookup()
 
-* Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com>  4.1.1-0
+* Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com>  5.0.0-0
 - Updated pki scheme
 - Application certs now managed in /etc/pki/simp_apps/simp_elasticsearch/x509
 
-* Fri Dec 30 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.1.1-0
+* Fri Dec 30 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 5.0.0-0
 - Cleaned up the manage_httpd logic
 
 * Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-0


### PR DESCRIPTION
Last tagged version was 4.1.0, so changes after that need to be 5.0.0.