### PR TITLE
(SIMP-4405) Update elastic/elasticsearch and puppetlabs/java

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -26,7 +26,7 @@ fixtures:
       ref: simp6.0.0-0.6.2
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
-      ref: 5.2.0
+      ref: 5.5.0
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1
@@ -36,7 +36,7 @@ fixtures:
     iptables: https://github.com/simp/pupmod-simp-iptables
     java:
       repo: https://github.com/simp/puppetlabs-java
-      ref: simp-1.6.0-post1
+      ref: 2.4.0
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     oddjob: https://github.com/simp/pupmod-simp-oddjob
     pam: https://github.com/simp/pupmod-simp-pam

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,8 +19,10 @@ fixtures:
       ref: 2.2.0
     compliance_mapper: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
+      # master is beyond 4.1.1, but has breaking changes to
+      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 3.0.0
+      ref: 4.1.1
     datacat:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
@@ -30,9 +32,7 @@ fixtures:
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1
-    haveged:
-      repo: https://github.com/simp/puppet-haveged
-      ref: 0.4.4
+    haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     java:
       repo: https://github.com/simp/puppetlabs-java

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@
 .setup_bundler_env: &setup_bundler_env
   before_script:
     - '(find .vendor | wc -l) || :'
-    - bundle || gem install bundler --no-rdoc --no-ri
+    - bundle check || gem install bundler --no-rdoc --no-ri
     - rm -f Gemfile.lock
     - rm -rf pkg/
     - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Feb 09 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.1-0
+- Update upperbound on puppetlabs/java version to < 3.0.0
+- Test with elastic/elasticsearch 5.5.0
+
 * Fri Jun 16 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Update custom Puppet 3 functions to namespaced, Puppet 4 functions
 - Update puppet requirement and remove OBE pe requirement in metadata.json

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.6.0 < 2.0.0"
+      "version_requirement": ">= 1.6.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -72,6 +72,7 @@ simp_options::firewall : true
 
         set_hieradata_on(host, hdata)
         apply_manifest_on(host, manifest, :catch_failures => true)
+        on(host, 'rpm -q elasticsearch')
       end
 
       it 'should be idempotent' do


### PR DESCRIPTION
- Update upperbound on puppetlabs/java version to < 3.0.0
- Test with elastic/elasticsearch 5.5.0

SIMP-4405 #comment simp_elasticsearch update to elastic/elasticsesarch 5.5.0
SIMP-4246 #comment simp_elasticsearch update puppetlabs/java < 3.0.0