### PR TITLE
(SIMP-4432) simp_elasticsearch: remove file_concat from fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -29,9 +29,6 @@ fixtures:
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
       ref: 5.5.0
-    file_concat:
-      repo: https://github.com/simp/puppet-lib-file_concat
-      ref: simp6.0.0-1.0.1
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     java:


### PR DESCRIPTION
file_concat is not used by pupmod-simp-simp_elasticsearch or any
of its test dependencies

SIMP-4432 #comment simp_elasticsearch remove file_concat from fixtures