### PR TITLE
(SIMP-5308) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 5.0.3-0
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 5.0.4-0
 - Updated $app_pki_external_source to accept any string. This matches the
   functionality of pki::copy.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 5.0.3-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Tue Aug 28 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 5.0.3-0
 - Add missing simp/pam dependency
 

--- a/manifests/pki.pp
+++ b/manifests/pki.pp
@@ -44,7 +44,7 @@
 #
 class simp_elasticsearch::pki(
   Variant[Boolean,Enum['simp']] $pki                     = simplib::lookup('simp_options::pki' , { 'default_value' => false }),
-  Stdlib::Absolutepath          $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::AbsolutePath          $app_pki_dir             = '/etc/pki/simp_apps/simp_elasticsearch/x509',
   Stdlib::AbsolutePath          $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
   Stdlib::AbsolutePath          $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated simp_elasticsearch
SIMP-5308 #close