### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     datacat:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Mar 08 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.6-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.rst
+
 * Mon Oct 29 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.5-0
 - Update badges and contribution guide URL in README.rst
 

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ This module has only been tested on Red Hat Enterprise Linux 6 and 7 and CentOS
 Development
 -----------
 
-Please read our `Contribution Guide <http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html>`__.
+Please read our `Contribution Guide <https://simp.readthedocs.io/en/stable/contributors_guide/index.html>`__.
 
 Acceptance tests
 ^^^^^^^^^^^^^^^^

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_elasticsearch",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-elasticsearch",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 6.0.0"
     },
     {
       "name": "simp/pam",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.rst

SIMP-6229 #comment pupmod-simp-simp_elasticsearch