### PR TITLE
(SIMP-6117) Use namespaced simplib::validate_net_list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 * Fri Mar 08 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.6-0
+- Use simplib::validate_net_list in lieu of deprecated Puppet 3
+  validate_net_list
+- Use simplib::validate_bool in lieu of deprecated Puppet 3
+  validate_bool_simp
+- Use simplib::validate_deep_hash in lieu of deprecated Puppet 3
+  validate_deep_hash
+- Use simp_apache::auth in lieu of simp_apache's deprecated Puppet 3
+  apache_auth
+- Use simp_apache::limits in lieu of simp_apache's deprecated Puppet 3
+  apache_limits
+- Update the upper bound of stdlib to < 6.0.0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.rst
 

--- a/lib/puppet/functions/simp_elasticsearch/iptables_format.rb
+++ b/lib/puppet/functions/simp_elasticsearch/iptables_format.rb
@@ -35,7 +35,7 @@ Puppet::Functions.create_function(:'simp_elasticsearch::iptables_format') do
         fail("simp_elasticsearch::iptables_format: Error, '#{es_host}' missing a valid port.")
       end
 
-      call_function('validate_net_list', Array(host))
+      call_function('simplib::validate_net_list', Array(host))
 
       iptables_rules << "-s #{host} -p tcp -m state --state NEW -m tcp -m multiport --dports #{port} -j ACCEPT"
     end

--- a/manifests/simp_apache.pp
+++ b/manifests/simp_apache.pp
@@ -133,12 +133,12 @@ class simp_elasticsearch::simp_apache (
       $method_acl
     )
 
-    validate_deep_hash( $::simp_apache::validate::method_acl, $_method_acl)
+    simplib::validate_deep_hash( $::simp_apache::validate::method_acl, $_method_acl)
 
     # These only work because we guarantee that we have content here.
     validate_absolute_path($_method_acl['method']['file']['user_file'])
-    validate_bool_simp($_method_acl['method']['ldap']['posix_group'])
-    validate_net_list(keys($_method_acl['limits']['hosts']))
+    simplib::validate_bool($_method_acl['method']['ldap']['posix_group'])
+    simplib::validate_net_list(keys($_method_acl['limits']['hosts']))
 
     $es_httpd_includes = '/etc/httpd/conf.d/elasticsearch'
 
@@ -178,7 +178,7 @@ class simp_elasticsearch::simp_apache (
       require => File[$es_httpd_includes]
     }
 
-    $_apache_auth = apache_auth($_method_acl['method'])
+    $_apache_auth = simp_apache::auth($_method_acl['method'])
 
     if !empty($_apache_auth) {
       file { "${es_httpd_includes}/auth/auth.conf":
@@ -192,7 +192,7 @@ class simp_elasticsearch::simp_apache (
       }
     }
 
-    $_apache_limits = apache_limits($_method_acl['limits'])
+    $_apache_limits = simp_apache::limits($_method_acl['limits'])
     $_apache_limits_content = $_apache_limits ? {
       # Set some sane defaults.
       ''      => "<Limit GET POST PUT DELETE>

--- a/metadata.json
+++ b/metadata.json
@@ -28,11 +28,11 @@
     },
     {
       "name": "simp/simp_apache",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.1 < 7.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/iptables",

--- a/spec/classes/simp_apache_spec.rb
+++ b/spec/classes/simp_apache_spec.rb
@@ -26,6 +26,7 @@ describe 'simp_elasticsearch::simp_apache' do
   Require all denied
   Satisfy any
 </Limit>
+
 <Limit POST>
   Order allow,deny
   Allow from 127.0.0.1
@@ -33,6 +34,7 @@ describe 'simp_elasticsearch::simp_apache' do
   Require all denied
   Satisfy any
 </Limit>
+
 <Limit PUT>
   Order allow,deny
   Allow from 127.0.0.1
@@ -40,6 +42,7 @@ describe 'simp_elasticsearch::simp_apache' do
   Require all denied
   Satisfy any
 </Limit>
+
 EOM
         ) }
 
@@ -119,6 +122,7 @@ EOM
   Require all denied
   Satisfy any
 </Limit>
+
 <Limit POST>
   Order allow,deny
   Allow from 1.2.3.4
@@ -128,6 +132,7 @@ EOM
   Require all denied
   Satisfy any
 </Limit>
+
 <Limit PUT>
   Order allow,deny
   Allow from 1.2.3.4
@@ -137,6 +142,7 @@ EOM
   Require all denied
   Satisfy any
 </Limit>
+
 EOM
         ) }
 


### PR DESCRIPTION
- Use simplib::validate_net_list in lieu of deprecated Puppet 3
  validate_net_list
- Use simplib::validate_bool in lieu of deprecated Puppet 3
  validate_bool_simp
- Use simp_apache::auth in lieu of simp_apache's deprecated Puppet 3
  apache_auth
- Use simp_apache::limits in lieu of simp_apache's deprecated Puppet 3
  apache_limits

SIMP-6117 #comment pupmod-simp-simp_elasticsearch