### PR TITLE
(SIMP-MAINT) Replace Puppet 3 array_size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@
   apache_auth
 - Use simp_apache::limits in lieu of simp_apache's deprecated Puppet 3
   apache_limits
+- Use Puppet built in function length in lieu of simplib's deprecated
+  Puppet 3 array_size
 - Update the upper bound of stdlib to < 6.0.0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.rst

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -5,7 +5,7 @@
 #
 class simp_elasticsearch::defaults {
 
-  if array_size($::simp_elasticsearch::unicast_hosts) < 3 {
+  if length($::simp_elasticsearch::unicast_hosts) < 3 {
     $min_master_nodes = 1
   }
   else {


### PR DESCRIPTION
Use Puppet built in function length in lieu of simplib's deprecated
Puppet 3 array_size